### PR TITLE
Changed WP env var to use URI.Port variable

### DIFF
--- a/DEV102/solutions/Lab_2/wordpress.json
+++ b/DEV102/solutions/Lab_2/wordpress.json
@@ -20,7 +20,7 @@
     "http://NAME.wordpress.kiso.io":80
   },
   "env":{
-    "WORDPRESS_DB_HOST": "{{ (binding_service \"mysql-srvc\").URI.Host }}:3306",
+    "WORDPRESS_DB_HOST": "{{ (binding_service \"mysql-srvc\").URI.Host }}:{{ (binding_service \"mysql-srvc\").URI.Port }}",
     "WORDPRESS_DB_USER": "{{ (binding_service \"mysql-srvc\").URI.User }}",
     "WORDPRESS_DB_PASSWORD": "{{ (binding_service \"mysql-srvc\").URI.Password }}",
     "WORDPRESS_DB_NAME": "{{ (binding_service \"mysql-srvc\").URI.TrimmedPath }}"


### PR DESCRIPTION
We made a corresponding change in the docs recently and made sense to keep them consistent
(see https://github.com/apcera/continuum-guide/pull/1058).

The main benefit is that the same manifest works with both CE and EE.

@yhyakuna @lparis 
